### PR TITLE
Fix wistia.py list project example

### DIFF
--- a/wistia.py
+++ b/wistia.py
@@ -33,7 +33,7 @@ if (options.cred is None):
 # list projects.
 w = wistia.api.WistiaAPI("api", options.cred)
 if (options.list_projects):
-	projects_json = w.list_projects()
+	projects_json = w.call("projects.json",{"sort_by": "created"})
 	projects = json.loads(projects_json)
 	for p in projects:
 		print "%s \"%s\" %s" % (p['id'], p['name'], p['mediaCount'])


### PR DESCRIPTION
Hey,
With the current state the example does not work and returns:
```
$ python wistia.py  -c ***-p
Traceback (most recent call last):
  File "wistia.py", line 36, in <module>
    projects_json = w.list_projects()
AttributeError: WistiaAPI instance has no attribute 'list_projects'
```

This change also makes it easier to understand how to call references, and also makes the code usable again.

